### PR TITLE
Connect MyList and Edit page when selecting a list

### DIFF
--- a/Client/Pages/Edit.razor
+++ b/Client/Pages/Edit.razor
@@ -42,6 +42,8 @@
     {
       ResetLinkBundle();
     }
+
+    StateContainer.OnChange += StateHasChanged;
   }
 
   private void NewLinkAdded(Link link)

--- a/Client/Pages/MyLists.razor
+++ b/Client/Pages/MyLists.razor
@@ -28,7 +28,7 @@
         {
           <div class="column is-one-quarter-widescreen is-one-third-desktop is-half-tablet">
             <img src="../assets/bg.png" alt class="list-dots is-pulled-right is-relative" />
-            <div class="card list-item is-relative" @onclick="EditList">
+            <div class="card list-item is-relative" @onclick="() => EditList(linkBundle)">
               <span class="list-count tag is-primary is-size-6 has-text-weight-bold">
                 @linkBundle.Links.Count Links
               </span>
@@ -63,14 +63,16 @@
     var response = await HttpContainer.GetAsync<List<LinkBundle>>($"api/user");
     return response.Data ?? new List<LinkBundle>();
   }
-  
+
   private void NewList()
   {
     NavigationManager.NavigateTo("/s/edit");
   }
 
-  private void EditList()
+  private void EditList(LinkBundle linkBundle)
   {
+    StateContainer.LinkBundle = linkBundle;
+    StateContainer.LinkBundle.IsPublished = true;
     NavigationManager.NavigateTo("/s/edit");
   }
 

--- a/Client/Shared/ListDetails.razor
+++ b/Client/Shared/ListDetails.razor
@@ -27,7 +27,7 @@
         <div class="column">
           <label class="control-label" for="description">Description</label>
           <textarea rows="2" title="Optional: The description will show up as the title on your public list page."
-            class="textarea has-fixed-size" id="description" v-model="currentList.description"></textarea>
+            class="textarea has-fixed-size" id="description" @bind="StateContainer.LinkBundle.Description"></textarea>
         </div>
         <div class="column is-narrow">
           <label class="control-label is-hidden-mobile" for>&nbsp;</label>


### PR DESCRIPTION
This pull request connects the MyList page and the Edit page when selecting a list. It also updates the Edit page to listen for the state change event.