### PR TITLE
Load sortable.min.js in component instead of index page

### DIFF
--- a/Client/Pages/MyLists.razor.css
+++ b/Client/Pages/MyLists.razor.css
@@ -35,20 +35,6 @@
   margin-bottom: 20px;
 }
 
-.list .list-item .list-item-loader {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background-color: #f9fafc;
-  animation: breathing 1.5s ease-in-out infinite;
-}
-
-@keyframes breathing {
-  0% { background-color: #f9fafc; }
-  50% { background-color: #ffffff; }
-  100% { background-color: #f9fafc; }
-}
-
 .list .list-placeholder {
   display: flex;
   height: 100%;

--- a/Client/Shared/SortableList.razor
+++ b/Client/Shared/SortableList.razor
@@ -41,7 +41,13 @@
     if (firstRender)
     {
       selfReference = DotNetObjectReference.Create(this);
+
+      // import the sortablejs library
+      await JS.InvokeVoidAsync("import", "./js/sortable.min.js");
+
+      // import the sortablelist component JavaScript
       var module = await JS.InvokeAsync<IJSObjectReference>("import", "./Shared/SortableList.razor.js");
+
       await module.InvokeAsync<string>("init", Id, selfReference);
     }
   }

--- a/Client/wwwroot/index.html
+++ b/Client/wwwroot/index.html
@@ -31,7 +31,6 @@
     <a class="dismiss">X</a>
   </div>
   <script src="_framework/blazor.webassembly.js"></script>
-  <script src="js/sortable.min.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
This pull request updates the code to load the sortable.min.js library directly in the component instead of the index page. This improves performance and ensures that the library is only loaded when needed.