### PR TITLE
Update API tests to include non-owned bundles

### DIFF
--- a/Api/ApiTests.http
+++ b/Api/ApiTests.http
@@ -2,7 +2,7 @@
 @clientPrincipal=eyJ1c2VySWQiOiJ0ZXN0VXNlciIsInVzZXJSb2xlcyI6WyJhbm9ueW1vdXMiLCAiYXV0aGVudGljYXRlZCJdLCJpZGVudGl0eVByb3ZpZGVyIjoidGVzdFByb3ZpZGVyIiwidXNlckRldGFpbHMiOiJ0ZXN0RGV0YWlscyJ9
 #original value: {"userId":"testUser","userRoles":["anonymous", "authenticated"],"identityProvider":"testProvider","userDetails":"testDetails"}
 
-POST http://localhost:{{port}}/api/linksi
+POST http://localhost:{{port}}/api/links
 x-ms-client-principal: {{clientPrincipal}}
 
 {
@@ -50,8 +50,8 @@ x-ms-client-principal: {{clientPrincipal}}
 {
   "links":[
     {
-      "id":"https://stackoverflow.com",
-      "url":"https://stackoverflow.com",
+      "id":"https://montemagno.com",
+      "url":"https://montemagno.com",
       "title":"Stack Overflow",
       "description":"Stack Overflow is the largest, most trusted online community for developers to learn, share their programming knowledge, and build their careers.",
       "image":""
@@ -86,3 +86,27 @@ x-ms-client-principal: {{clientPrincipal}}
 ###
 DELETE http://localhost:{{port}}/api/links/test
 x-ms-client-principal: {{clientPrincipal}}
+
+###
+DELETE http://localhost:{{port}}/api/links/jons-links
+x-ms-client-principal: {{clientPrincipal}}
+
+###
+PUT http://localhost:{{port}}/api/links/jons-links
+x-ms-client-principal: {{clientPrincipal}}
+
+{
+  "links":[
+    {
+      "id":"https://montemagno.com",
+      "url":"https://montemagno.com",
+      "title":"Stack Overflow",
+      "description":"Stack Overflow is the largest, most trusted online community for developers to learn, share their programming knowledge, and build their careers.",
+      "image":""
+    }
+  ],
+  "vanityUrl":"test",
+  "description":"",
+  "userId":"",
+"id":"ffffffff-ffff-ffff-ffff-ffffffffffff"
+}


### PR DESCRIPTION
The most significant changes include the modification of the POST and DELETE request URLs in `ApiTests.http`, the update of the `id` and `url` fields in the PUT request, and the addition of a new PUT request.

1. The POST request URL in `ApiTests.http` was updated from `/api/linksi` to `/api/links`. This change is crucial as it corrects the endpoint to which the POST request is sent, ensuring that the request is processed correctly.

2. The `id` and `url` fields in the PUT request to `/api/links/test` were updated from `https://stackoverflow.com` to `https://montemagno.com`. This change is important as it updates the link that the PUT request is modifying.

3. The DELETE request URL was updated from `/api/links/test` to `/api/links/jons-links`. This change is significant as it alters the specific link that the DELETE request is targeting.

4. A new PUT request was added to `/api/links/jons-links` with a new link object. The link object has `id` and `url` fields set to `https://montemagno.com`, `title` set to `Stack Overflow`, and `description` set to a brief about Stack Overflow. The `image` field is empty. The request also includes `vanityUrl` set to `test`, an empty `description` and `userId` fields, and `id` set to `ffffffff-ffff-ffff-ffff-ffffffffffff`. This addition is significant as it introduces a new link object that can be modified with the PUT request.

References to the code changes can be found in the `ApiTests.http` file.