### PR TITLE
Add editorconfig to Client projectd with 2 space indents for razor files

### DIFF
--- a/Client/.editorconfig
+++ b/Client/.editorconfig
@@ -1,0 +1,35 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = tab
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = false
+file_header_template = unset
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+
+# Razor files
+[*.razor]
+
+# Indentation and spacing
+indent_size = 2
+indent_style = space
+tab_width = 2

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -27,4 +27,12 @@
     <_ContentIncludedByDefault Remove="Shared/ModalConfirm.razor" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EditorConfigFiles Remove="D:\Users\Jon\Documents\GitHub\BlazorSWA\Client\.editorconfig" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="D:\Users\Jon\Documents\GitHub\BlazorSWA\Client\.editorconfig" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This pull request primarily focuses on the introduction of an `.editorconfig` file to the `Client` directory and the incorporation of this file into the `Client.csproj` file. The `.editorconfig` file is used to define and maintain consistent coding styles between different editors and IDEs, and in this case, it specifies indentation and spacing rules for C# and Razor files, as well as some .NET coding conventions. 

Key changes include:

* [`Client/.editorconfig`](diffhunk://#diff-a4c6f7d9b994496daf306e080c8ed5f485ef69d606d9e1d5e399d1cc2b3f7c20R1-R35): A new `.editorconfig` file has been added to the `Client` directory. This file specifies various coding styles such as indentation size and style, tab width, end of line preference, and whether to insert a final newline. It also sets some .NET coding conventions like the organization of 'using' directives and the use of 'this.' and 'Me.' preferences.

* [`Client/Client.csproj`](diffhunk://#diff-cb6e2472227a42647c6af15228e61447a1c4326666616b9562cec522f40f4a69R30-R37): The `.editorconfig` file has been incorporated into the `Client.csproj` file. This ensures that the coding styles defined in the `.editorconfig` file are applied when working with the `Client` project.