### PR TITLE
Bump version on actions/checkout

### DIFF
--- a/.github/workflows/azure-static-web-apps-victorious-forest-0ccd7d90f.yml
+++ b/.github/workflows/azure-static-web-apps-victorious-forest-0ccd7d90f.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Build And Deploy


### PR DESCRIPTION
Fixes warning about Node 16 being deprecated per https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/