### PR TITLE
Remove EditForm and Regular Expressions to cut dependencies.

### DIFF
--- a/Client/Shared/LinkBundleDetails.razor
+++ b/Client/Shared/LinkBundleDetails.razor
@@ -70,16 +70,12 @@
 
     if (String.IsNullOrEmpty(vanityUrl)) return;
 
-    // Create a ValidationContext based on the LinkBundle object
-    var context = new ValidationContext(StateContainer.LinkBundle, null, null);
-    // This list will hold the results of the validation
-    var results = new List<ValidationResult>();
-    // Perform the data annotations validation
-    listIsValid = Validator.TryValidateObject(StateContainer.LinkBundle, context, results, true);
-
-    // if the data annotations validation fails, no need to check if the vanity url is taken
-    if (!listIsValid) {
-      validationErrorMessage = results.FirstOrDefault()?.ErrorMessage ?? "";
+    // Ensure the vanity url contains only letters, numbers, and dashes without using regex
+    if (vanityUrl.Any(c => !char.IsLetterOrDigit(c) && c != '-'))
+    {
+      // if the data annotations validation fails, no need to check if the vanity url is taken
+      listIsValid = false;
+      validationErrorMessage = "Vanity URLs can only contain letters, numbers, and dashes.";
       return;
     }
 

--- a/Client/Shared/NewLink.razor
+++ b/Client/Shared/NewLink.razor
@@ -2,35 +2,57 @@
 @inject HttpClient Http
 @inject StateContainer StateContainer
 
-<EditForm Model="@Model" OnValidSubmit="@OnValidSubmit" class="mb-6">
-  <DataAnnotationsValidator />
-  <p>Enter a link and press enter</p>
-  <InputText @ref="newLinkInput" class="input is-large is-size-2" @bind-Value="Model!.Url" id="newLink"
-    placeholder="http://example.com" ParsingErrorMessage="That doesn't look like a valid URL" />
-  <ValidationMessage class="has-text-danger is-font-weight-medium mt-2" For="() => Model.Url" />
-</EditForm>
+<form method="post" @formname="newlinkform" @onsubmit="OnSubmit" class="mb-6">
+    <p>Enter a link and press enter</p>
+    <input @ref="newLinkInput" id="newLink" @bind-value="linkurl" placeholder="http://example.com" class="input is-large is-size-2 modified">
+    <div class="is-font-weight-medium mt-2 @((invalid ? "has-text-danger" : "is-hidden"))">That doesn't look like a valid URL</div>
+</form>
 
 @code {
-    private InputText? newLinkInput;
-
-    public Link? Model { get; set; }
-
-    protected override void OnInitialized() => Model ??= new();
+    private string? linkurl;
+    private bool invalid = false;
+    private ElementReference newLinkInput;
 
     [Parameter]
     public EventCallback<Link> OnNewLinkAdded { get; set; }
 
-    private async Task OnValidSubmit()
+    private async Task OnSubmit()
     {
+        if (!ValidateUrl(linkurl))
+        {
+            invalid = true;
+            StateHasChanged();
+            return;
+        }
+
+        invalid = false;
+
         var link = new Link
-      {
-        Url = Model!.Url!
-      };
+            {
+                Url = linkurl
+            };
 
         await OnNewLinkAdded.InvokeAsync(link);
-        Model.Url = null;
-        await newLinkInput!.Element!.Value.FocusAsync();
+        linkurl = null;
+        await newLinkInput.FocusAsync();
         await GetOpenGraphInfoForLink(link);
+    }
+
+    private bool ValidateUrl(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return false;
+        }
+
+        if (!url.StartsWith("http://") && !url.StartsWith("https://"))
+        {
+            url = "http://" + url;
+        }
+
+        return Uri.TryCreate(url, UriKind.Absolute, out Uri uriResult)
+          && (uriResult.Scheme == Uri.UriSchemeHttp
+          || uriResult.Scheme == Uri.UriSchemeHttps) && uriResult.Host.Replace("www.", "").Split('.').Count() > 1 && uriResult.HostNameType == UriHostNameType.Dns && uriResult.Host.Length > uriResult.Host.LastIndexOf(".") + 1;
     }
 
     private async Task GetOpenGraphInfoForLink(Link link)
@@ -45,21 +67,21 @@
             var response = await Http.PostAsJsonAsync<Link>("api/oginfo", link, cts.Token);
             var updatedLink = await response.Content.ReadFromJsonAsync<Link>();
 
-      if (updatedLink != null)
-      {
-        // call statecontainer updatelink
-        StateContainer.UpdateLinkInBundle(link, updatedLink);
-      }
+            if (updatedLink != null)
+            {
+                // call statecontainer updatelink
+                StateContainer.UpdateLinkInBundle(link, updatedLink);
+            }
+        }
+        catch (Exception e)
+        {
+            // the request to get opengraph info failed, so log and swallow
+            Console.WriteLine(e);
+            StateContainer.RemoveLinkFromUpdatePool(link);
+        }
+        finally
+        {
+            StateContainer.RemoveLinkFromUpdatePool(link);
+        }
     }
-    catch (Exception e)
-    {
-      // the request to get opengraph info failed, so log and swallow
-      Console.WriteLine(e);
-      StateContainer.RemoveLinkFromUpdatePool(link);
-    }
-    finally
-    {
-      StateContainer.RemoveLinkFromUpdatePool(link);
-    }
-  }
 }

--- a/Shared/Link.cs
+++ b/Shared/Link.cs
@@ -1,16 +1,11 @@
 using System;
-using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
 
 namespace BlazorApp.Shared
 {
     public class Link
     {
         public string Id { get; set; } = Guid.NewGuid().ToString();
-
-        [RegularExpression(@"^(https?://)?([\w-]+\.)+[\w-]+(/[\w- ./:?%&=#]*)?$", ErrorMessage = "That doesn't look like a valid URL"), Required]
         public string Url { get; set; }
-
         public string Title { get; set; }
         public string Description { get; set; }
         public string Image { get; set; }

--- a/Shared/LinkBundle.cs
+++ b/Shared/LinkBundle.cs
@@ -9,7 +9,7 @@ namespace BlazorApp.Shared
     {
         [JsonPropertyName("id")]
         public string Id { get; set; } = Guid.NewGuid().ToString();
-        [JsonPropertyName("vanityUrl"), RegularExpression(@"^(^$|[a-zA-Z0-9_\-])+$", ErrorMessage = "Only letters, numbers and dashes")]
+        [JsonPropertyName("vanityUrl")]
         public string VanityUrl { get; set; }
         [JsonPropertyName("description")]
         public string Description { get; set; }
@@ -17,7 +17,6 @@ namespace BlazorApp.Shared
         public string UserId { get; set; }
         [JsonPropertyName("provider")]
         public string Provider { get; set; }
-
         [JsonPropertyName("links")]
         public List<Link> Links { get; set; } = new List<Link>();
     }


### PR DESCRIPTION
Refactor URL validation and form handling in LinkBundle and NewLink

Refactored the validation process for the `VanityUrl` property in the `LinkBundle` class to check for letters, numbers, and dashes without using regex. The `NewLink.razor` file was significantly refactored, replacing the `EditForm` component with a standard HTML form and the `OnValidSubmit` method with an `OnSubmit` method that includes a URL validation check. The `Link` and `LinkBundle` classes no longer use data annotations or regular expressions for URL validation. Minor refactoring was also done on the `GetOpenGraphInfoForLink` method in `NewLink.razor`, mainly for code formatting and indentation.