### PR TITLE
Add authentication providers to staticwebapp.config.json

### DIFF
--- a/Client/staticwebapp.config.json
+++ b/Client/staticwebapp.config.json
@@ -1,5 +1,33 @@
 {
     "navigationFallback": {
         "rewrite": "/index.html"
+    },
+    "auth": {
+        "identityProviders": {
+            "google": {
+                "registration": {
+                    "clientIdSettingName": "GOOGLE_CLIENT_ID",
+                    "clientSecretSettingName": "GOOGLE_CLIENT_SECRET"
+                }
+            },
+            "twitter": {
+                "registration": {
+                    "consumerKeySettingName": "TWITTER_CONSUMER_KEY",
+                    "consumerSecretSettingName": "TWITTER_CONSUMER_SECRET"
+                }
+            },
+            "github": {
+                "registration": {
+                    "clientIdSettingName": "GITHUB_CLIENT_ID",
+                    "clientSecretSettingName": "GITHUB_CLIENT_SECRET"
+                }
+            },
+            "facebook": {
+                "registration": {
+                    "appIdSettingName": "FACEBOOK_APP_ID",
+                    "appSecretSettingName": "FACEBOOK_APP_SECRET"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request adds authentication providers to the staticwebapp.config.json file. The authentication providers included are Google, Twitter, GitHub, and Facebook. This allows users to authenticate using their accounts from these platforms.